### PR TITLE
pkg/files: make read file optional in ListFiles

### DIFF
--- a/pkg/files/manager.go
+++ b/pkg/files/manager.go
@@ -40,18 +40,16 @@ func (fm *FileManagerImpl) CreateFile(ctx context.Context, fs afero.Fs, path, co
 		return nil, NewFileAlreadyExistsError(path)
 	}
 
-	file := model.NewFile(path, content)
-
-	dir := filepath.Dir(file.Path)
+	dir := filepath.Dir(path)
 	if err := fs.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("Failed to create directory %s: %w", dir, err)
 	}
 
-	if err := writeFile(fs, file); err != nil {
+	if err := afero.WriteFile(fs, path, []byte(content), 0o644); err != nil {
 		return nil, fmt.Errorf("Failed to write file %s: %w", path, err)
 	}
 
-	return file, nil
+	return model.NewFile(path, content), nil
 }
 
 func (fm *FileManagerImpl) ReadFile(ctx context.Context, fs afero.Fs, path string) (*model.File, error) {

--- a/pkg/files/manager_test.go
+++ b/pkg/files/manager_test.go
@@ -326,11 +326,10 @@ func TestUpdateFile_Failure(t *testing.T) {
 func TestListFile(t *testing.T) {
 	// RUN test
 	for _, tt := range []struct {
-		name       string
-		fs         afero.Fs
-		filter     files.PatternFilter
-		showHidden bool
-		wantPath   []string
+		name     string
+		fs       afero.Fs
+		opts     []files.ListFileOption
+		wantPath []string
 	}{
 		{
 			name: "all files",
@@ -367,9 +366,7 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter:     files.PatternFilter{},
-			showHidden: false,
-			wantPath:   []string{"/hello.txt", "/something/something.txt", "/something/items.json", "/node_modules/module1/file.js", "/node_modules/module2/file.js"},
+			wantPath: []string{"/hello.txt", "/something/something.txt", "/something/items.json", "/node_modules/module1/file.js", "/node_modules/module2/file.js"},
 		},
 		{
 			name: "with exclude filter",
@@ -406,12 +403,13 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"*something*"},
-				Exclude: []string{"*.json", "node_modules"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"*something*"},
+					Exclude: []string{"*.json", "node_modules"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/something/something.txt"},
+			wantPath: []string{"/something/something.txt"},
 		},
 		{
 			name: "match directory anywhere",
@@ -448,11 +446,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"**/logs/**"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"**/logs/**"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs/debug.log", "/logs/monday/foo.bar", "/build/logs/debug.log"},
+			wantPath: []string{"/logs/debug.log", "/logs/monday/foo.bar", "/build/logs/debug.log"},
 		},
 		{
 			name: "match directory with file",
@@ -481,11 +480,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"**/logs/debug.log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"**/logs/debug.log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs/debug.log", "/build/logs/debug.log"},
+			wantPath: []string{"/logs/debug.log", "/build/logs/debug.log"},
 		},
 		{
 			name: "match file extension",
@@ -522,11 +522,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"*.log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"*.log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs/debug.log", "/logs/build/debug.log", "/build/logs/debug.log"},
+			wantPath: []string{"/logs/debug.log", "/logs/build/debug.log", "/build/logs/debug.log"},
 		},
 		{
 			name: "match file extension with exclude",
@@ -555,12 +556,13 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"*.log"},
-				Exclude: []string{"**/build/**"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"*.log"},
+					Exclude: []string{"**/build/**"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs/debug.log"},
+			wantPath: []string{"/logs/debug.log"},
 		},
 		{
 			name: "include files only from root",
@@ -585,11 +587,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"/debug.log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"/debug.log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/debug.log"},
+			wantPath: []string{"/debug.log"},
 		},
 		{
 			name: "include files by name",
@@ -614,11 +617,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"**/debug.log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"**/debug.log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/debug.log", "/build/debug.log"},
+			wantPath: []string{"/debug.log", "/build/debug.log"},
 		},
 		{
 			name: "include files with question mark",
@@ -647,11 +651,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"**/debug?.log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"**/debug?.log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/debug0.log", "/debug1.log"},
+			wantPath: []string{"/debug0.log", "/debug1.log"},
 		},
 		{
 			name: "include files with numeric range",
@@ -680,11 +685,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"**/debug[0-9].log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"**/debug[0-9].log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/debug0.log", "/debug1.log"},
+			wantPath: []string{"/debug0.log", "/debug1.log"},
 		},
 		{
 			name: "include files with character set",
@@ -717,11 +723,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"**/debug[01].log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"**/debug[01].log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/debug0.log", "/debug1.log"},
+			wantPath: []string{"/debug0.log", "/debug1.log"},
 		},
 		{
 			name: "include files with negated character set",
@@ -754,11 +761,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"/debug[!01].log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"/debug[!01].log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/debug2.log", "/debug3.log"},
+			wantPath: []string{"/debug2.log", "/debug3.log"},
 		},
 		{
 			name: "include files with alphabetical range",
@@ -787,11 +795,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"/debug[a-z].log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"/debug[a-z].log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/debuga.log"},
+			wantPath: []string{"/debuga.log"},
 		},
 		{
 			name: "include files and directories",
@@ -828,11 +837,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"**/logs*", "**/logs/**"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"**/logs*", "**/logs/**"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs.txt", "/logs/debug.log", "/logs/latest/foo.bar", "/build/logs.txt", "/build/logs/debug.log"},
+			wantPath: []string{"/logs.txt", "/logs/debug.log", "/logs/latest/foo.bar", "/build/logs.txt", "/build/logs/debug.log"},
 		},
 		{
 			name: "include only directories",
@@ -869,11 +879,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"**/logs/**"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"**/logs/**"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs/debug.log", "/logs/latest/foo.bar", "/build/logs/debug.log"},
+			wantPath: []string{"/logs/debug.log", "/logs/latest/foo.bar", "/build/logs/debug.log"},
 		},
 		{
 			name: "include with double asterisk",
@@ -902,11 +913,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"/logs/**/debug.log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"/logs/**/debug.log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs/debug.log", "/logs/monday/debug.log", "/logs/monday/pm/debug.log"},
+			wantPath: []string{"/logs/debug.log", "/logs/monday/debug.log", "/logs/monday/pm/debug.log"},
 		},
 		{
 			name: "include with wildcard in directory",
@@ -935,11 +947,12 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"/logs/*day/debug.log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"/logs/*day/debug.log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs/monday/debug.log"},
+			wantPath: []string{"/logs/monday/debug.log"},
 		},
 		{
 			name: "include file with directory",
@@ -968,17 +981,18 @@ func TestListFile(t *testing.T) {
 				}
 				return fs
 			}(),
-			filter: files.PatternFilter{
-				Include: []string{"/logs/debug.log"},
+			opts: []files.ListFileOption{
+				files.ListFilesWithFilter(files.PatternFilter{
+					Include: []string{"/logs/debug.log"},
+				}),
 			},
-			showHidden: false,
-			wantPath:   []string{"/logs/debug.log"},
+			wantPath: []string{"/logs/debug.log"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			fm := files.NewFileManager()
 
-			files, err := fm.ListFiles(context.Background(), tt.fs, tt.showHidden, tt.filter)
+			files, err := fm.ListFiles(context.Background(), tt.fs, tt.opts...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/files/mocks/mock_manager.go
+++ b/pkg/files/mocks/mock_manager.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/artmoskvin/hide/pkg/files"
 	"github.com/artmoskvin/hide/pkg/model"
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
 )
 
@@ -45,4 +46,13 @@ func (m *MockFileManager) ApplyPatch(ctx context.Context, fs afero.Fs, path, pat
 
 func (m *MockFileManager) UpdateLines(ctx context.Context, fs afero.Fs, path string, lineDiff files.LineDiffChunk) (*model.File, error) {
 	return m.UpdateLinesFunc(ctx, fs, path, lineDiff)
+}
+
+func DiffListFilesOpts(want files.ListFilesOptions, got ...files.ListFileOption) (diff string) {
+	gotO := &files.ListFilesOptions{}
+	for _, o := range got {
+		o(gotO)
+	}
+
+	return cmp.Diff(*gotO, want)
 }

--- a/pkg/handlers/list_files.go
+++ b/pkg/handlers/list_files.go
@@ -24,11 +24,9 @@ func (h ListFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	showHidden := r.URL.Query().Has("showHidden")
+	opts := getListFilesOptions(r)
 
-	filter := getPatternFilter(r)
-
-	files, err := h.ProjectManager.ListFiles(r.Context(), projectID, showHidden, filter)
+	files, err := h.ProjectManager.ListFiles(r.Context(), projectID, opts...)
 	if err != nil {
 		var projectNotFoundError *project.ProjectNotFoundError
 		if errors.As(err, &projectNotFoundError) {

--- a/pkg/handlers/search_files.go
+++ b/pkg/handlers/search_files.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/artmoskvin/hide/pkg/files"
 	"github.com/artmoskvin/hide/pkg/model"
 	"github.com/artmoskvin/hide/pkg/project"
 )
@@ -74,10 +75,9 @@ func (h SearchFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filter := getPatternFilter(r)
-
+	opts := append(getListFilesOptions(r), files.ListFilesWithContent())
 	listFiles := func(ctx context.Context, showHidden bool) ([]*model.File, error) {
-		return h.ProjectManager.ListFiles(ctx, projectID, showHidden, filter)
+		return h.ProjectManager.ListFiles(ctx, projectID, opts...)
 	}
 
 	result, err := findInFiles(r.Context(), listFiles, check)

--- a/pkg/handlers/search_files_test.go
+++ b/pkg/handlers/search_files_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/artmoskvin/hide/pkg/files"
+	mockfiles "github.com/artmoskvin/hide/pkg/files/mocks"
 	"github.com/artmoskvin/hide/pkg/handlers"
 	"github.com/artmoskvin/hide/pkg/model"
 	"github.com/artmoskvin/hide/pkg/project/mocks"
@@ -148,10 +149,16 @@ func TestSearchFileHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := handlers.SearchFilesHandler{
 				ProjectManager: &mocks.MockProjectManager{
-					ListFilesFunc: func(ctx context.Context, projectId string, showHidden bool, filter files.PatternFilter) ([]*model.File, error) {
-						if diff := cmp.Diff(filter, tt.wantFilter); diff != "" {
+					ListFilesFunc: func(ctx context.Context, projectId string, opts ...files.ListFileOption) ([]*model.File, error) {
+						diff := mockfiles.DiffListFilesOpts(files.ListFilesOptions{
+							WithContent: true,
+							Filter:      tt.wantFilter,
+						}, opts...)
+
+						if diff != "" {
 							return nil, fmt.Errorf("filter does not match, diff %s", diff)
 						}
+
 						return modelFiles, nil
 					},
 				},

--- a/pkg/handlers/utils.go
+++ b/pkg/handlers/utils.go
@@ -29,6 +29,14 @@ func getPathValue(r *http.Request, key string) (string, error) {
 	return value, nil
 }
 
+func getListFilesOptions(r *http.Request) []files.ListFileOption {
+	opts := []files.ListFileOption{files.ListFilesWithFilter(getPatternFilter(r))}
+	if r.URL.Query().Has("showHidden") {
+		opts = append(opts, files.ListFilesWithShowHidden())
+	}
+	return opts
+}
+
 func getPatternFilter(r *http.Request) files.PatternFilter {
 	filter := files.PatternFilter{}
 

--- a/pkg/project/mocks/mock_manager.go
+++ b/pkg/project/mocks/mock_manager.go
@@ -22,7 +22,7 @@ type MockProjectManager struct {
 	DeleteProjectFunc    func(ctx context.Context, projectId string) <-chan result.Empty
 	GetProjectFunc       func(ctx context.Context, projectId string) (model.Project, error)
 	GetProjectsFunc      func(ctx context.Context) ([]*model.Project, error)
-	ListFilesFunc        func(ctx context.Context, projectId string, showHidden bool, filter files.PatternFilter) ([]*model.File, error)
+	ListFilesFunc        func(ctx context.Context, projectId string, opts ...files.ListFileOption) ([]*model.File, error)
 	ReadFileFunc         func(ctx context.Context, projectId, path string) (*model.File, error)
 	ResolveTaskAliasFunc func(ctx context.Context, projectId string, alias string) (devcontainer.Task, error)
 	SearchSymbolsFunc    func(ctx context.Context, projectId model.ProjectId, query string, symbolFilter lsp.SymbolFilter) ([]lsp.SymbolInfo, error)
@@ -74,8 +74,8 @@ func (m *MockProjectManager) DeleteFile(ctx context.Context, projectId, path str
 	return m.DeleteFileFunc(ctx, projectId, path)
 }
 
-func (m *MockProjectManager) ListFiles(ctx context.Context, projectId string, showHidden bool, filter files.PatternFilter) ([]*model.File, error) {
-	return m.ListFilesFunc(ctx, projectId, showHidden, filter)
+func (m *MockProjectManager) ListFiles(ctx context.Context, projectId string, opts ...files.ListFileOption) ([]*model.File, error) {
+	return m.ListFilesFunc(ctx, projectId, opts...)
 }
 
 func (m *MockProjectManager) ApplyPatch(ctx context.Context, projectId, path, patch string) (*model.File, error) {


### PR DESCRIPTION
This PR introduces `ListFileOption` that include `WithContent` flag. When the flag is set to true `ListFiles()` will also read content of the file as it did previously which is useful for search etc, otherwise it will return `EmptyFile()` that contains only path.