### PR TITLE
pkg/gitignore: bugfix missing Close()

### DIFF
--- a/pkg/gitignore/dir.go
+++ b/pkg/gitignore/dir.go
@@ -99,6 +99,7 @@ func readDir(fs afero.Fs, dir string) ([]os.FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer d.Close()
 
 	return d.Readdir(0)
 }


### PR DESCRIPTION
Might cause "too many open files in system" on large projects. 