### PR TITLE
pkg/lsp: shutdown lsp servers gracefully

### DIFF
--- a/pkg/lsp/process.go
+++ b/pkg/lsp/process.go
@@ -19,6 +19,7 @@ type Process interface {
 	Start() error
 	Stop() error
 	ReadWriteCloser() io.ReadWriteCloser
+	Wait() error
 }
 
 type readWriteCloser struct {
@@ -72,4 +73,8 @@ func (p *ProcessImpl) Stop() error {
 
 func (p *ProcessImpl) ReadWriteCloser() io.ReadWriteCloser {
 	return p.rwc
+}
+
+func (p *ProcessImpl) Wait() error {
+	return p.cmd.Wait()
 }


### PR DESCRIPTION
This PR changes how we shutdown LSP servers. Instead of killing the process, we send the `shutdown` request and then `exit` notification. Finally, we call `exec.Cmd.Wait()` that is required according to documentation https://pkg.go.dev/os/exec#Cmd.Wait