### PR TITLE
cmd: remove timeouts

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -124,8 +124,6 @@ var runCmd = &cobra.Command{
 		server := &http.Server{
 			Handler:      router,
 			Addr:         addr,
-			WriteTimeout: 300 * time.Second,
-			ReadTimeout:  300 * time.Second,
 		}
 
 		log.Info().Msgf("Server started on %s\n", addr)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -124,8 +124,8 @@ var runCmd = &cobra.Command{
 		server := &http.Server{
 			Handler:      router,
 			Addr:         addr,
-			WriteTimeout: 120 * time.Second,
-			ReadTimeout:  120 * time.Second,
+			WriteTimeout: 300 * time.Second,
+			ReadTimeout:  300 * time.Second,
 		}
 
 		log.Info().Msgf("Server started on %s\n", addr)


### PR DESCRIPTION
For big repositories, like astropy, django, the create project and the run task requests fail with the timeout. This PR removed the server timeouts as a short-term mitigation. Long-term, we should switch to async processing and expose additional endpoints for checking the status of a project or a task.