### PR TITLE
pkg/lsp: run in separate process group for graceful shutdown

### DIFF
--- a/pkg/lsp/process.go
+++ b/pkg/lsp/process.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"syscall"
 )
 
 type Command struct {
@@ -43,14 +44,18 @@ type ProcessImpl struct {
 
 func NewProcess(command Command) (Process, error) {
 	cmd := exec.Command(command.name, command.args...)
-	stdin, err := cmd.StdinPipe()
 
+	// Set SysProcAttr to create a new process group
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create stdin pipe: %w", err)
 	}
 
 	stdout, err := cmd.StdoutPipe()
-
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create stdout pipe: %w", err)
 	}


### PR DESCRIPTION
Solves the issue where process is terminated on SIGNAL. Seems like LSP process is in the same process group as main and on SIGKILL it is terminated "concurrently" with main. However we run manual gracefully shutdown, which results in errors. 
 
```bash
2024-10-12T01:07:21.809+02:00 DBG pkg/devcontainer/image_manager.go:142 > Local image exists image=mcr.microsoft.com/devcontainers/go:1.22
2024-10-12T01:07:22.544+02:00 DBG pkg/lsp/service.go:101 > Initialized language server languageId=Go projectId=nGS39iNnPr
2024-10-12T01:07:22.544+02:00 DBG pkg/lsp/service.go:105 > LSP server supports open/close file: true languageId=Go projectId=nGS39iNnPr
2024-10-12T01:07:22.544+02:00 DBG pkg/lsp/service.go:106 > LSP server supports change notifications: 2 languageId=Go projectId=nGS39iNnPr
2024-10-12T01:07:22.544+02:00 DBG pkg/project/manager.go:168 > Created project nGS39iNnPr for repo https://github.com/hide-org/hide.git
2024-10-12T01:07:22.544+02:00 DBG pkg/lsp/service.go:338 > Start listening projectId=nGS39iNnPr
2024-10-12T01:07:55.65+02:00 DBG pkg/project/manager.go:197 > Deleting project nGS39iNnPr
2024-10-12T01:08:05.861+02:00 DBG pkg/lsp/service.go:348 > Done listening projectId=nGS39iNnPr
2024-10-12T01:08:05.887+02:00 DBG pkg/project/manager.go:220 > Deleted project nGS39iNnPr
^C2024-10-12T01:08:08.96+02:00 INF cmd/run.go:139 > Server shutting down ...
2024-10-12T01:08:08.96+02:00 INF pkg/project/manager.go:266 > Cleaning up projects
2024-10-12T01:08:08.96+02:00 INF pkg/project/manager.go:300 > Cleaned up projects
👋 Goodbye!
```

Pre 
```bash
2024-10-12T01:16:04.847+02:00 INF pkg/project/manager.go:266 > Cleaning up projects
2024-10-12T01:16:04.847+02:00 DBG pkg/project/manager.go:197 > Deleting project e5zwnRgIgY
2024-10-12T01:16:04.848+02:00 DBG pkg/project/manager.go:197 > Deleting project q7t59Eix60
2024-10-12T01:16:15.042+02:00 ERR pkg/lsp/client.go:99 > Failed to shutdown LSP server error="jsonrpc2: connection is closed"
2024-10-12T01:16:15.042+02:00 ERR pkg/project/manager.go:211 > Failed to stop LSP server(s) error="jsonrpc2: connection is closed" projectId=q7t59Eix60
2024-10-12T01:16:15.049+02:00 ERR pkg/lsp/client.go:99 > Failed to shutdown LSP server error="jsonrpc2: connection is closed"
2024-10-12T01:16:15.049+02:00 ERR pkg/project/manager.go:211 > Failed to stop LSP server(s) error="jsonrpc2: connection is closed" projectId=e5zwnRgIgY
2024-10-12T01:16:15.049+02:00 WRN cmd/run.go:141 > Failed to cleanup projects error="Errors occurred during cleanup: [Failed to stop LSP server(s): jsonrpc2: connection is closed Failed to stop LSP server(s): jsonrpc2: connection is closed]"```